### PR TITLE
Fixed meridian bug in 'current' time initialization

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -137,8 +137,10 @@
                     if ( this.showMeridian ) {
                         if (hours === 0) {
                             hours = 12;
-                        } else if (hours > 12) {
-                            hours = hours - 12;
+                        } else if (hours >= 12) {
+                            if (hours > 12) {
+                                hours = hours - 12;
+                            }
                             meridian = "PM";
                         } else {
                            meridian = "AM";


### PR DESCRIPTION
If the timepicker was initialized with 'current' during 12:00 - 12:59, the meridian would be incorrectly chosen as AM.  Fixed to correctly choose PM.
