### PR TITLE
Ensure elements do not hijack focus. 

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -60,7 +60,7 @@
                     focus: $.proxy(this.highlightUnit, this),
                     click: $.proxy(this.highlightUnit, this),
                     keypress: $.proxy(this.elementKeypress, this),
-                    blur: $.proxy(this.updateFromElementVal, this)
+                    blur: $.proxy(this.blurElement, this)
                 });
 
             } else {
@@ -68,14 +68,14 @@
                     this.$element.on({
                         focus: $.proxy(this.showWidget, this),
                         click: $.proxy(this.showWidget, this),
-                        blur: $.proxy(this.updateFromElementVal, this)
+                        blur: $.proxy(this.blurElement, this)
                     });
                 } else {
                     this.$element.on({
                         focus: $.proxy(this.highlightUnit, this),
                         click: $.proxy(this.highlightUnit, this),
                         keypress: $.proxy(this.elementKeypress, this),
-                        blur: $.proxy(this.updateFromElementVal, this)
+                        blur: $.proxy(this.blurElement, this)
                     });
                 }
             }
@@ -426,6 +426,11 @@
         , update: function() {
             this.updateElement();
             this.updateWidget();
+        }
+
+        , blurElement: function() {
+          this.highlightedUnit = undefined;
+          this.updateFromElementVal();
         }
 
         , updateElement: function() {


### PR DESCRIPTION
This pull request resolves a problem with the default timepicker implementation hijacking the user's focus indefinitely. The only resolution was to refresh the page. 

This commit simply sets the highlightedUnit to undefined when the blurEvent is fired. 

Updates #30. 
