### PR TITLE
Compiled css missing z-index

### DIFF
--- a/compiled/timepicker.css
+++ b/compiled/timepicker.css
@@ -6,6 +6,7 @@
     padding: 4px;
     top: 0;
     min-width: 10px;
+    z-index: 99999;
 }
 .bootstrap-timepicker.dropdown-menu.open {
     display: inline-block;


### PR DESCRIPTION
Compiled css didn't have timepicker dropdown-menu z-index declaration
which causes it to not show up when timepicker is used as a text field
inside of a modal.
