### PR TITLE
Sets the meridian if the defaultTime option is set to null.

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -430,6 +430,9 @@
         }
 
         , update: function() {
+            if (this.showMeridian && this.meridian === undefined) {
+              this.meridian = 'AM';
+            }
             this.updateElement();
             this.updateWidget();
         }


### PR DESCRIPTION
Fixes an issue that causes the time in the input field to display as "1:00 undefined" when the hour or minute arrows are clicked if the `defaultTime` option is set to `null`.  This is probably a fringe case but I needed it to be blank until the user actioned one of the arrows.
