### PR TITLE
Empty Input's will no longer be automatically filled with 00:00:00

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -79,10 +79,10 @@
                     });
                 }
             }
-            
+
 
             this.$widget = $(this.getTemplate()).appendTo('body');
-            
+
             this.$widget.on('click', $.proxy(this.widgetClick, this));
 
             if (this.showInputs) {
@@ -91,7 +91,7 @@
                     keypress: $.proxy(this.widgetKeypress, this),
                     change: $.proxy(this.updateFromWidgetInputs, this)
                 });
-            } 
+            }
 
             this.setDefaultTime(this.defaultTime);
         }
@@ -139,7 +139,7 @@
 
         , hideWidget: function(){
             this.$element.trigger('hide');
-            
+
             if (this.template === 'modal') {
                 this.$widget.modal('hide');
             } else {
@@ -166,11 +166,11 @@
             switch (e.keyCode) {
                 case 9: //tab
                     if (this.showMeridian) {
-                        if (input == 'meridian') { 
+                        if (input == 'meridian') {
                             this.hideWidget();
                         }
                     } else {
-                        if (this.showSeconds) { 
+                        if (this.showSeconds) {
                             if (input == 'second') {
                                 this.hideWidget();
                             }
@@ -234,7 +234,7 @@
                             this.highlightNextUnit();
                         }
                     } else {
-                        if (this.showSeconds) { 
+                        if (this.showSeconds) {
                             if (this.highlightedUnit != 'second') {
                                 e.preventDefault();
                                 this.highlightNextUnit();
@@ -293,7 +293,7 @@
                     this.updateElement();
                 break;
             }
-            
+
             if (e.keyCode !== 0 && e.keyCode !== 8 && e.keyCode !== 9 && e.keyCode !== 46) {
                 e.preventDefault();
             }
@@ -314,7 +314,7 @@
 
             if (isNaN(this.hour)) {
                 this.hour = 0;
-            } 
+            }
             if (isNaN(this.minute)) {
                 this.minute = 0;
             }
@@ -330,7 +330,7 @@
                     this.meridian = 'AM';
                 } else if (this.meridian == 'pm' || this.meridian == 'p') {
                     this.meridian = 'PM';
-                } 
+                }
 
                 if (this.meridian != 'AM' && this.meridian != 'PM') {
                     this.meridian = 'AM';
@@ -359,7 +359,8 @@
                 }
             }
 
-            this.updateElement();
+            if ( this.$element.val() != '' )
+                this.updateElement();
             this.updateWidget();
         }
 
@@ -404,7 +405,9 @@
                 } else {
                     this.setValues(defaultTime);
                 }
-                this.update();
+                if ( this.$element.val() != '' )
+                    this.updateElement();
+                this.updateWidget();
             } else {
                 this.hour = 0;
                 this.minute = 0;
@@ -491,13 +494,13 @@
         }
 
         , updateFromWidgetInputs: function () {
-            var time = $('input.bootstrap-timepicker-hour', this.$widget).val() + ':' + 
+            var time = $('input.bootstrap-timepicker-hour', this.$widget).val() + ':' +
                        $('input.bootstrap-timepicker-minute', this.$widget).val() +
-                       (this.showSeconds ? 
-                           ':' + $('input.bootstrap-timepicker-second', this.$widget).val() 
+                       (this.showSeconds ?
+                           ':' + $('input.bootstrap-timepicker-second', this.$widget).val()
                         : '') +
-                       (this.showMeridian ? 
-                           ' ' + $('input.bootstrap-timepicker-meridian', this.$widget).val() 
+                       (this.showMeridian ?
+                           ' ' + $('input.bootstrap-timepicker-meridian', this.$widget).val()
                         : '');
 
             this.setValues(time);
@@ -583,25 +586,25 @@
 
         , highlightHour: function() {
             this.highlightedUnit = 'hour';
-            this.$element.get(0).setSelectionRange(0,2); 
+            this.$element.get(0).setSelectionRange(0,2);
         }
 
         , highlightMinute: function() {
             this.highlightedUnit = 'minute';
-            this.$element.get(0).setSelectionRange(3,5); 
+            this.$element.get(0).setSelectionRange(3,5);
         }
 
         , highlightSecond: function() {
             this.highlightedUnit = 'second';
-            this.$element.get(0).setSelectionRange(6,8); 
+            this.$element.get(0).setSelectionRange(6,8);
         }
 
         , highlightMeridian: function() {
             this.highlightedUnit = 'meridian';
             if (this.showSeconds) {
-                this.$element.get(0).setSelectionRange(9,11); 
+                this.$element.get(0).setSelectionRange(9,11);
             } else {
-                this.$element.get(0).setSelectionRange(6,8); 
+                this.$element.get(0).setSelectionRange(6,8);
             }
         }
 
@@ -623,7 +626,7 @@
             if (this.showMeridian) {
                 if (this.hour === 1) {
                     return this.hour = 12;
-                } 
+                }
                 else if (this.hour === 12) {
                     this.toggleMeridian();
                 }
@@ -700,11 +703,11 @@
                                            '<td><a href="#" data-action="incrementHour"><i class="icon-chevron-up"></i></a></td>'+
                                            '<td class="separator">&nbsp;</td>'+
                                            '<td><a href="#" data-action="incrementMinute"><i class="icon-chevron-up"></i></a></td>'+
-                                           (this.showSeconds ? 
+                                           (this.showSeconds ?
                                                '<td class="separator">&nbsp;</td>'+
                                                '<td><a href="#" data-action="incrementSecond"><i class="icon-chevron-up"></i></a></td>'
                                            : '') +
-                                           (this.showMeridian ? 
+                                           (this.showMeridian ?
                                                '<td class="separator">&nbsp;</td>'+
                                                '<td class="meridian-column"><a href="#" data-action="toggleMeridian"><i class="icon-chevron-up"></i></a></td>'
                                            : '') +
@@ -713,11 +716,11 @@
                                            '<td>'+ hourTemplate +'</td> '+
                                            '<td class="separator">:</td>'+
                                            '<td>'+ minuteTemplate +'</td> '+
-                                           (this.showSeconds ? 
+                                           (this.showSeconds ?
                                                 '<td class="separator">:</td>'+
                                                 '<td>'+ secondTemplate +'</td>'
                                            : '') +
-                                           (this.showMeridian ? 
+                                           (this.showMeridian ?
                                                 '<td class="separator">&nbsp;</td>'+
                                                 '<td>'+ meridianTemplate +'</td>'
                                            : '') +
@@ -726,11 +729,11 @@
                                            '<td><a href="#" data-action="decrementHour"><i class="icon-chevron-down"></i></a></td>'+
                                            '<td class="separator"></td>'+
                                            '<td><a href="#" data-action="decrementMinute"><i class="icon-chevron-down"></i></a></td>'+
-                                           (this.showSeconds ? 
+                                           (this.showSeconds ?
                                                 '<td class="separator">&nbsp;</td>'+
-                                                '<td><a href="#" data-action="decrementSecond"><i class="icon-chevron-down"></i></a></td>' 
+                                                '<td><a href="#" data-action="decrementSecond"><i class="icon-chevron-down"></i></a></td>'
                                            : '') +
-                                           (this.showMeridian ? 
+                                           (this.showMeridian ?
                                                 '<td class="separator">&nbsp;</td>'+
                                                 '<td><a href="#" data-action="toggleMeridian"><i class="icon-chevron-down"></i></a></td>'
                                            : '') +
@@ -752,14 +755,14 @@
                                        '<a href="#" class="btn btn-primary" data-dismiss="modal">Ok</a>'+
                                    '</div>'+
                                '</div>';
-                    
+
                 break;
                 case 'dropdown':
                     template = '<div class="bootstrap-timepicker dropdown-menu">'+
                                     templateContent +
                                '</div>';
                 break;
-                
+
             }
             return template;
         }


### PR DESCRIPTION
When you assign the timepicker to an empty/blank form input element, when the plugin loaded it would always automatically populate the input with `00:00:00`.  I altered the code slightly so that it will not auto-populate like this and will instead leave the input blank, as the user intended.
