### PR TITLE
Fix chevron color and text decoration for bootstrap 2.2.1

### DIFF
--- a/less/timepicker.less
+++ b/less/timepicker.less
@@ -78,8 +78,10 @@
                 margin: 0;
                 padding: 8px 0;
                 outline: 0;
+                color: #333;
 
                 &:hover {
+                    text-decoration: none;
                     background-color: #eee;
                     -webkit-border-radius: 4px;
                     -moz-border-radius: 4px;


### PR DESCRIPTION
This fixes the link color and decoration of the timepicker
chevrons. The structure of timepicker dropdown-menu doesn't
match the bootstrap structure (.dropdown > li) so the bootstrap
rules don't change the link color and text decoration.
