### PR TITLE
Added "destroy" method

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -786,6 +786,7 @@
             , data = $this.data('timepicker')
             , options = typeof option == 'object' && option;
             if (!data) {
+                if(option == 'destroy'){return;}
                 $this.data('timepicker', (data = new Timepicker(this, options)));
             }
             if (typeof option == 'string') {

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -57,25 +57,25 @@
             if (this.$element.parent().hasClass('input-append')) {
                 this.$element.parent('.input-append').find('.add-on').on('click', $.proxy(this.showWidget, this));
                 this.$element.on({
-                    focus: $.proxy(this.highlightUnit, this),
-                    click: $.proxy(this.highlightUnit, this),
-                    keypress: $.proxy(this.elementKeypress, this),
-                    blur: $.proxy(this.blurElement, this)
+                    'focus.timepicker': $.proxy(this.highlightUnit, this),
+                    'click.timepicker': $.proxy(this.highlightUnit, this),
+                    'keypress.timepicker': $.proxy(this.elementKeypress, this),
+                    'blur.timepicker': $.proxy(this.blurElement, this)
                 });
 
             } else {
                 if (this.template) {
                     this.$element.on({
-                        focus: $.proxy(this.showWidget, this),
-                        click: $.proxy(this.showWidget, this),
-                        blur: $.proxy(this.blurElement, this)
+                        'focus.timepicker': $.proxy(this.showWidget, this),
+                        'click.timepicker': $.proxy(this.showWidget, this),
+                        'blur.timepicker': $.proxy(this.blurElement, this)
                     });
                 } else {
                     this.$element.on({
-                        focus: $.proxy(this.highlightUnit, this),
-                        click: $.proxy(this.highlightUnit, this),
-                        keypress: $.proxy(this.elementKeypress, this),
-                        blur: $.proxy(this.blurElement, this)
+                        'focus.timepicker': $.proxy(this.highlightUnit, this),
+                        'click.timepicker': $.proxy(this.highlightUnit, this),
+                        'keypress.timepicker': $.proxy(this.elementKeypress, this),
+                        'blur.timepicker': $.proxy(this.blurElement, this)
                     });
                 }
             }
@@ -87,13 +87,20 @@
 
             if (this.showInputs) {
                 this.$widget.find('input').on({
-                    click: function() { this.select(); },
-                    keypress: $.proxy(this.widgetKeypress, this),
-                    change: $.proxy(this.updateFromWidgetInputs, this)
+                    'click.timepicker': function() { this.select(); },
+                    'keypress.timepicker': $.proxy(this.widgetKeypress, this),
+                    'change.timepicker': $.proxy(this.updateFromWidgetInputs, this)
                 });
             }
 
             this.setDefaultTime(this.defaultTime);
+        }
+        
+        , destroy: function() {
+          var $element = this.$element;
+          this.$widget.remove();
+          $.removeData($element[0],'timepicker');
+          $element.off('.timepicker');
         }
 
         , showWidget: function(e) {

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -55,7 +55,7 @@
 
         , init: function () {
             if (this.$element.parent().hasClass('input-append')) {
-                this.$element.parent('.input-append').find('.add-on').on('click', $.proxy(this.showWidget, this));
+                this.$element.parent('.input-append').find('.add-on').on('click.timepicker', $.proxy(this.showWidget, this));
                 this.$element.on({
                     'focus.timepicker': $.proxy(this.highlightUnit, this),
                     'click.timepicker': $.proxy(this.highlightUnit, this),
@@ -101,6 +101,7 @@
           this.$widget.remove();
           $.removeData($element[0],'timepicker');
           $element.off('.timepicker');
+          $element.parent('.input-append').find('.add-on').off('.timepicker');
         }
 
         , showWidget: function(e) {


### PR DESCRIPTION
I've added a destroy method wich can be very helpful in some situations.

For example: if we are loading HTML content - which contains timepicker inputs -
dynamically, if some of this content needs to be removed, we should also destroy
any timepicker inside of it, in order to keep the DOM cleaner and removing
jQuery data and event listeners that are no longer needed.
