### PR TITLE
Added useful info about time in show/hide timepicker event

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -329,13 +329,7 @@
 
       this.$element.trigger({
         'type': 'hide.timepicker',
-        'time': this.getTime(),
-        'info': {
-              'hours': this.hour,
-              'minutes': this.minute,
-              'seconds': this.second,
-              'meridian': this.meridian
-        }
+        'time': this.getTime()
       });
 
       if (this.template === 'modal') {
@@ -606,13 +600,7 @@
 
       this.$element.trigger({
         'type': 'show.timepicker',
-        'time': this.getTime(),
-        'info': {
-                      'hours': this.hour,
-                    'minutes': this.minute,
-                    'seconds': this.second,
-                    'meridian': this.meridian
-                }
+        'time': this.getTime()
       });
 
       if (this.disableFocus) {

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -329,7 +329,13 @@
 
       this.$element.trigger({
         'type': 'hide.timepicker',
-        'time': this.getTime()
+        'time': {
+            'value': this.getTime(),
+            'hours': this.hour,
+            'minutes': this.minute,
+            'seconds': this.second,
+            'meridian': this.meridian
+         }
       });
 
       if (this.template === 'modal') {
@@ -600,7 +606,13 @@
 
       this.$element.trigger({
         'type': 'show.timepicker',
-        'time': this.getTime()
+        'time': {
+            'value': this.getTime(),
+            'hours': this.hour,
+            'minutes': this.minute,
+            'seconds': this.second,
+            'meridian': this.meridian
+         }
       });
 
       if (this.disableFocus) {

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -329,7 +329,13 @@
 
       this.$element.trigger({
         'type': 'hide.timepicker',
-        'time': this.getTime()
+        'time': this.getTime(),
+        'info': {
+              'hours': this.hour,
+              'minutes': this.minute,
+              'seconds': this.second,
+              'meridian': this.meridian
+        }
       });
 
       if (this.template === 'modal') {
@@ -600,7 +606,13 @@
 
       this.$element.trigger({
         'type': 'show.timepicker',
-        'time': this.getTime()
+        'time': this.getTime(),
+        'info': {
+                      'hours': this.hour,
+                    'minutes': this.minute,
+                    'seconds': this.second,
+                    'meridian': this.meridian
+                }
       });
 
       if (this.disableFocus) {


### PR DESCRIPTION
When receiving this events, I wanted not only the string with the time, but also the hours, minutes, seconds and meridian selected. Parsing the string was too dirty, so I added this data to the event.

Regards,
Tom
