### PR TITLE
Fixed bower version

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
     "name": "bootstrap-timepicker",
-    "version": "0.1.2",
+    "version": "0.2.1",
     "description": "A timepicker component for Twitter Bootstrap 2.x",
     "repository": {
       "type": "git",


### PR DESCRIPTION
```
mismatch The version specified in the component.json of package bootstrap-timepicker mismatches the tag (0.2.1 vs 0.1.2)
mismatch You should report this problem to the package author
```
