### PR TITLE
Add a new option appendWidgetTo

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -26,6 +26,7 @@
     this.showMeridian = options.showMeridian;
     this.showSeconds = options.showSeconds;
     this.template = options.template;
+    this.appendWidgetTo = options.appendWidgetTo;
 
     this._init();
   };
@@ -65,7 +66,7 @@
       }
 
       if (this.template !== false) {
-        this.$widget = $(this.getTemplate()).appendTo(this.$element.parents('.bootstrap-timepicker')).on('click', $.proxy(this.widgetClick, this));
+        this.$widget = $(this.getTemplate()).appendTo(this.$element.parents(this.appendWidgetTo)).on('click', $.proxy(this.widgetClick, this));
       } else {
         this.$widget = false;
       }
@@ -859,7 +860,8 @@
     showSeconds: false,
     showInputs: true,
     showMeridian: true,
-    template: 'dropdown'
+    template: 'dropdown',
+    appendWidgetTo: ".bootstrap-timepicker"
   };
 
   $.fn.timepicker.Constructor = Timepicker;


### PR DESCRIPTION
Added a new option to timepicker allowing for custom placing of the modal widget.
This was needed because of IE7.

There is a gist with the HTML needed to reproduce the error.

https://gist.github.com/pedroma/4961018

After applying the changes in this pull-request if you initialize 
$("#myModal input").timepicker({appendWidgetTo:"#myModal .modal-body"});

and it works.
