### PR TITLE
Prepend timepicker instead of append.

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -66,7 +66,7 @@
       }
 
       if (this.template !== false) {
-        this.$widget = $(this.getTemplate()).appendTo(this.$element.parents(this.appendWidgetTo)).on('click', $.proxy(this.widgetClick, this));
+        this.$widget = $(this.getTemplate()).prependTo(this.$element.parents(this.appendWidgetTo)).on('click', $.proxy(this.widgetClick, this));
       } else {
         this.$widget = false;
       }


### PR DESCRIPTION
This is necessary because when it gets appended, bootstrap styles won't work correctly: border-radius won't get applied to the .add-on element because it is not a :last-child.
