### PR TITLE
Position widget relative to appended container

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -67,6 +67,21 @@
 
       if (this.template !== false) {
         this.$widget = $(this.getTemplate()).appendTo(this.$element.parents(this.appendWidgetTo)).on('click', $.proxy(this.widgetClick, this));
+
+        if (this.appendWidgetTo != '.bootstrap-timepicker') {
+          var offset = { x:0, y:0};
+          this.$element.parentsUntil(this.appendWidgetTo).each(function(i, el) {
+            var $el = $(el);
+            if ($el.css('position') != 'relative') return;
+            var elOffset = $el.position();
+            offset.x += elOffset.left;
+            offset.y += elOffset.top;
+          });
+          this.$widget.css({
+            top: offset.y + this.$element.height() + 5,
+            left: offset.x
+          });
+        }
       } else {
         this.$widget = false;
       }

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -78,7 +78,7 @@
             offset.y += elOffset.top;
           });
           this.$widget.css({
-            top: offset.y + this.$element.height() + 5,
+            top: offset.y + this.$element.outerHeight() - 5,
             left: offset.x
           });
         }


### PR DESCRIPTION
I was having problems with using this widget inside a bootstrap modal. Since `.modal-content` scrolls overflowing content, and the widget is absolutely positioned, it gets cut off if it would hang over the bottom.

This patch calculates the offset of the target element relative to the chosen `appendWidgetTo` container, and positions the widget accordingly.
