### PR TITLE
Made minute decrements lock to 0-based minuteStep

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -118,7 +118,8 @@
       if (step) {
         newVal = this.minute - step;
       } else {
-        newVal = this.minute - this.minuteStep;
+        newVal = this.minute - this.minuteStep +
+          ((this.minuteStep - this.minute) % this.minuteStep);
       }
 
       if (newVal < 0) {


### PR DESCRIPTION
@mindeavor's [pull](https://github.com/jdewit/bootstrap-timepicker/pull/1) only fixed behaviour of minute incrementing; it didn't fix decrementing. This pull fixes minute decrementing.
