### PR TITLE
Added touch event handler for hiding timepicker on iOS devices

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -364,7 +364,7 @@
         this.$widget.removeClass('open');
       }
 
-      $(document).off('mousedown.timepicker');
+      $(document).off('mousedown.timepicker, touchend.timepicker');
 
       this.isOpen = false;
     },
@@ -662,7 +662,7 @@
       }
 
       var self = this;
-      $(document).on('mousedown.timepicker', function (e) {
+      $(document).on('mousedown.timepicker, touchend.timepicker', function (e) {
         // Clicked outside the timepicker, hide it
         if ($(e.target).closest('.bootstrap-timepicker-widget').length === 0) {
           self.hideWidget();


### PR DESCRIPTION
Mousedown doesn't work on iOS devices, so I've added just two event handlers to the ones you had.
