### PR TITLE
Handle appended and prepended buttons.

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -38,7 +38,7 @@
       var self = this;
 
       if (this.$element.parent().hasClass('input-append') || this.$element.parent().hasClass('input-prepend')) {
-        this.$element.parent('.input-append, .input-prepend').find('.add-on').on({
+        this.$element.parent('.input-append, .input-prepend').children(':not(input)').on({
           'click.timepicker': $.proxy(this.showWidget, this)
         });
         this.$element.on({


### PR DESCRIPTION
Previous version only handled .add-ons - but bootstrap supports prepending/appending .btn classes as well. And in fact, those make more sense because they are clearly clickable.
