### PR TITLE
Implement shift+tab actions to move to previous time fields

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -146,24 +146,44 @@
       switch (e.keyCode) {
       case 9: //tab
         this.updateFromElementVal();
-
-        switch (this.highlightedUnit) {
-        case 'hour':
-          e.preventDefault();
-          this.highlightNextUnit();
-          break;
-        case 'minute':
-          if (this.showMeridian || this.showSeconds) {
+        
+        if (e.shiftKey) {
+          switch (this.highlightedUnit) {
+          case 'hour':
+	    // default action shift+tab action
+            break;
+          case 'minute':
+       	    e.preventDefault();
+            this.highlightPrevUnit();
+            break;
+          case 'second':
+            e.preventDefault();
+            this.highlightPrevUnit();
+            break;
+          case 'meridian':
+            e.preventDefault();
+            this.highlightPrevUnit();
+            break;
+          }
+        } else {
+          switch (this.highlightedUnit) {
+          case 'hour':
             e.preventDefault();
             this.highlightNextUnit();
+            break;
+          case 'minute':
+            if (this.showMeridian || this.showSeconds) {
+              e.preventDefault();
+              this.highlightNextUnit();
+            }
+            break;
+          case 'second':
+            if (this.showMeridian) {
+              e.preventDefault();
+              this.highlightNextUnit();
+            }
+            break;
           }
-          break;
-        case 'second':
-          if (this.showMeridian) {
-            e.preventDefault();
-            this.highlightNextUnit();
-          }
-          break;
         }
         break;
       case 27: // escape


### PR DESCRIPTION
From an accessibility review we're conducting on our code: the existing shift+tab order breaks user expectations by moving forward, rather than backward between time field elements.  This change looks at the shiftKey property on the event and highlights the previous field, instead of the next.
