### PR TITLE
highlightPrevUnit does not highlight minutes correctly if not showing meridian or seconds

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -416,7 +416,13 @@
     highlightPrevUnit: function() {
       switch (this.highlightedUnit) {
       case 'hour':
-        this.highlightMeridian();
+          if(this.showMeridian){
+            this.highlightMeridian();
+          } else if (this.showSeconds) {
+            this.highlightSecond();
+          } else {
+            this.highlightMinute();
+          }
         break;
       case 'minute':
         this.highlightHour();


### PR DESCRIPTION
To reproduce the bug:
on the demo page, using the 2nd time picker (Inside a modal with 24hr mode and seconds enabled.) Do the following:

Test 1:
1. click into the hours field. Note that it is highlighted. If you press up or down the hours cycle.
2. press the left arrow key
3. note that the seconds field is not highlighted, and that the cursor appears to be after that field. 
4. press the up or down arrow, the seconds field does not cycle. (this is the bug)
5. now press the left key. The seconds field is selected and cycles properly. 

Test 2: 
1. click into the field and select the seconds field
2. press the right arrow key and the cursor will move into the hours field and highlight it.
3. press the up or down arrows and the hours field will cycle (this is asymmetric from the previous test)
