### PR TITLE
Update documentation links and format

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ View <a href="http://jdewit.github.com/bootstrap-timepicker">demos & documentati
 Support
 =======
 
-If you make money using this timepicker, please consider 
+If you make money using this timepicker, please consider
 supporting its development.
 
 <a href="http://www.pledgie.com/campaigns/19125"><img alt="Click here to support bootstrap-timepicker!" src="http://www.pledgie.com/campaigns/19125.png?skin_name=chrome" border="0" target="_blank"/></a> <a class="FlattrButton" style="display:none;" rev="flattr;button:compact;" href="http://jdewit.github.com/bootstrap-timepicker"></a> <noscript><a href="http://flattr.com/thing/1116513/Bootstrap-Timepicker" target="_blank"> <img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0" /></a></noscript>
@@ -27,28 +27,30 @@ Contributing
     npm install
 ```
 
-3. Use <a href="https://github.com/twitter/bower">Bower</a> to get the dev dependencies.
+3. Use <a href="https://github.com/bower/bower">Bower</a> to get the
+   dev dependencies.
 
-``` bash 
+``` bash
 $ bower install
 ```
 
-4. Use <a href="www.gruntjs.com">Grunt</a> to run tests, compress assets, etc. 
+4. Use <a href="http://www.gruntjs.com">Grunt</a> to run tests,
+   compress assets, etc.
 
-``` bash 
+``` bash
 $ grunt test // run jshint and jasmine tests
 $ grunt watch // run jsHint and Jasmine tests whenever a file is changed
 $ grunt compile // minify the js and css files
 ```
 
-- Please make it easy on me by covering any new features or issues 
+- Please make it easy on me by covering any new features or issues
 with <a href="http://pivotal.github.com/jasmine">Jasmine</a> tests.
 - If your changes need documentation, please take the time to update the docs.
 
 Acknowledgements
 ================
 
-Thanks to everyone who have given feedback and submitted pull requests. A 
+Thanks to everyone who have given feedback and submitted pull requests. A
 list of all the contributors can be found <a href="https://github.com/jdewit/bootstrap-timepicker/graphs/contributors">here</a>.
 
-Special thanks to @eternicode and his <a href="https://github.com/eternicode/bootstrap-datepicker">Twitter Datepicker</a> for inspiration.    
+Special thanks to @eternicode and his <a href="https://github.com/eternicode/bootstrap-datepicker">Twitter Datepicker</a> for inspiration.

--- a/README.md
+++ b/README.md
@@ -19,30 +19,28 @@ supporting its development.
 Contributing
 ============
 
-1. Install <a href="www.nodejs.org">NodeJS</a> and <a href="www.npmjs.org">Node Package Manager</a>.
+1. Install <a href="www.nodejs.org">NodeJS</a> and
+   <a href="www.npmjs.org">Node Package Manager</a>.
 
-2. Install packages
+1. Install packages
 
-``` bash
-    npm install
-```
+        npm install
 
-3. Use <a href="https://github.com/bower/bower">Bower</a> to get the
+
+1. Use <a href="https://github.com/bower/bower">Bower</a> to get the
    dev dependencies.
 
-``` bash
-$ bower install
-```
+        $ bower install
 
-4. Use <a href="http://www.gruntjs.com">Grunt</a> to run tests,
+1. Use <a href="http://www.gruntjs.com">Grunt</a> to run tests,
    compress assets, etc.
 
-``` bash
-$ grunt test // run jshint and jasmine tests
-$ grunt watch // run jsHint and Jasmine tests whenever a file is changed
-$ grunt compile // minify the js and css files
-```
 
+        $ grunt test // run jshint and jasmine tests
+        $ grunt watch // run jsHint and Jasmine tests whenever a file is changed
+        $ grunt compile // minify the js and css files
+
+<!-- New list -->
 - Please make it easy on me by covering any new features or issues
 with <a href="http://pivotal.github.com/jasmine">Jasmine</a> tests.
 - If your changes need documentation, please take the time to update the docs.


### PR DESCRIPTION
# Problem description

The current documentation contains bad links and trailing spaces.
# Changes description

Fix link to bower as it is now hosted on a separate URL.
Fix link for grunt.
Remove trailing whitespaces as they are not needed.

Fix numbered list and force separation of the 2 lists.
# How to try and test the changes

Go to this page and check the formated Markdown https://github.com/chevah/bootstrap-timepicker/tree/update-documentation

Thanks!
