### PR TITLE
Fix dropdown arrow for pull-right.

### DIFF
--- a/css/bootstrap-timepicker.css
+++ b/css/bootstrap-timepicker.css
@@ -57,14 +57,6 @@
   position: absolute;
   top: -6px;
 }
-.bootstrap-timepicker-widget.pull-right.dropdown-menu:before {
-  left: inherit;
-  right: 9px;
-}
-.bootstrap-timepicker-widget.pull-right.dropdown-menu:after {
-  left: inherit;
-  right: 10px;
-}
 .bootstrap-timepicker-widget a.btn,
 .bootstrap-timepicker-widget input {
   border-radius: 4px;

--- a/css/bootstrap-timepicker.css
+++ b/css/bootstrap-timepicker.css
@@ -57,6 +57,14 @@
   position: absolute;
   top: -6px;
 }
+.bootstrap-timepicker-widget.pull-right.dropdown-menu:before {
+  left: inherit;
+  right: 9px;
+}
+.bootstrap-timepicker-widget.pull-right.dropdown-menu:after {
+  left: inherit;
+  right: 10px;
+}
 .bootstrap-timepicker-widget a.btn,
 .bootstrap-timepicker-widget input {
   border-radius: 4px;

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -26,6 +26,7 @@
     this.showSeconds = options.showSeconds;
     this.template = options.template;
     this.appendWidgetTo = options.appendWidgetTo;
+    this.pullRight = options.pullRight;
 
     this._init();
   };
@@ -255,7 +256,8 @@
         minuteTemplate,
         secondTemplate,
         meridianTemplate,
-        templateContent;
+        templateContent,
+        templateExtraClasses;
 
       if (this.showInputs) {
         hourTemplate = '<input type="text" name="hour" class="bootstrap-timepicker-hour" maxlength="2"/>';
@@ -267,6 +269,11 @@
         minuteTemplate = '<span class="bootstrap-timepicker-minute"></span>';
         secondTemplate = '<span class="bootstrap-timepicker-second"></span>';
         meridianTemplate = '<span class="bootstrap-timepicker-meridian"></span>';
+      }
+
+      templateExtraClasses = '';
+      if (this.pullRight) {
+        templateExtraClasses += ' pull-right';
       }
 
       templateContent = '<table>'+
@@ -327,7 +334,9 @@
         '</div>';
         break;
       case 'dropdown':
-        template = '<div class="bootstrap-timepicker-widget dropdown-menu">'+ templateContent +'</div>';
+        template = '<div class="bootstrap-timepicker-widget dropdown-menu '+ templateExtraClasses + '">'+
+              templateContent +
+            '</div>';
         break;
       }
 
@@ -880,7 +889,8 @@
     showInputs: true,
     showMeridian: true,
     template: 'dropdown',
-    appendWidgetTo: '.bootstrap-timepicker'
+    appendWidgetTo: '.bootstrap-timepicker',
+    pullRight: false
   };
 
   $.fn.timepicker.Constructor = Timepicker;

--- a/less/timepicker.less
+++ b/less/timepicker.less
@@ -11,25 +11,7 @@
 .bootstrap-timepicker {
     position: relative;
 
-    &.pull-right {
-        .bootstrap-timepicker-widget {
-            &.dropdown-menu {
-                left: auto;
-                right: 0;
-
-                &:before {
-                    left: auto;
-                    right: 12px;
-                }
-                &:after {
-                    left: auto;
-                    right: 13px;
-                }
-            }
-        }
-    }
-
-    .add-on { 
+    .add-on {
         cursor: pointer;
         i {
            display: inline-block;
@@ -38,9 +20,26 @@
         }
     }
 }
+
 .bootstrap-timepicker-widget {
+    &.pull-right {
+        &.dropdown-menu {
+            left: auto;
+            right: 0;
+
+            &:before {
+                left: auto;
+                right: 12px;
+            }
+            &:after {
+                left: auto;
+                right: 13px;
+            }
+        }
+    }
+
     &.dropdown-menu {
-        padding: 2px 3px 2px 2px; 
+        padding: 2px 3px 2px 2px;
         &.open {
             display: inline-block;
         }
@@ -74,7 +73,7 @@
         width: 100%;
         margin: 0;
 
-        td { 
+        td {
             text-align: center;
             height: 30px;
             margin: 0;
@@ -124,8 +123,8 @@
 
 @media (min-width: 767px) {
     .bootstrap-timepicker-widget.modal {
-        width: 200px; 
-        margin-left: -100px; 
+        width: 200px;
+        margin-left: -100px;
     }
 }
 

--- a/spec/js/TimepickerSpec.js
+++ b/spec/js/TimepickerSpec.js
@@ -397,4 +397,60 @@ describe('Timepicker feature', function() {
     expect(tp1.isOpen).toBe(true);
   });
 
+  describe('initialization', function() {
+
+    var $customInput;
+
+    afterEach(function() {
+      if ($customInput) {
+        $customInput.data('timepicker').remove();
+      }
+      $('#timepickerCustom').remove();
+    });
+
+    var createWidget = function(content, options) {
+      if (!options) {
+        options = {};
+      }
+      $('body').append(
+        '<div id="timepickerCustom" class="bootstrap-timepicker">' +
+          content +
+        '</div>');
+      $customInput = $('#timepickerCustom input').timepicker(options);
+    };
+
+    it('appends the drop-down to the requested element', function() {
+      createWidget(
+        '<div id="dropdown-target"></div>' +
+        '<input type="text"/>' +
+        {appendWidgetTo: '#dropdown-target'}
+        );
+
+      expect(
+        $('#timepickerCustom > div.bootstrap-timepicker-widget').length).toBe(0);
+      expect(
+        $('#dropdown-target > div.bootstrap-timepicker-widget').length).toBe(1);
+    });
+
+    it('does not set pull-right class when pullRight option is not requested', function() {
+      createWidget('<input type="text"/>');
+
+      expect(
+        $('#timepickerCustom div.bootstrap-timepicker-widget').hasClass(
+          'pull-right')).toBe(false);
+    });
+
+    it('sets pull-right class when pullRight option is requested', function() {
+      createWidget(
+        '<input type="text"/>',
+        {pullRight: true}
+        );
+
+      expect(
+        $('#timepickerCustom div.bootstrap-timepicker-widget').hasClass(
+          'pull-right')).toBe(true);
+    });
+
+  });
+
 });


### PR DESCRIPTION
# Problem description

There is no option to set dropdown menu to pull right when you don't want the whole field to be pulled left.

The LESS selecter pull-right seems to be overwritten by the normal pull-left rules. 
# Changes description

Added a configuration option to set pullRight.

I don't master the CSS/LESS so I have the LESS to place dropdown arrow on the right when pull-right is defined.
I have re-arrange the order of rules so that pull-right will take creater priority.

I have removed all trailing spaces for LESS file.

Before

![after](https://f.cloud.github.com/assets/204609/1033283/22952356-0ef9-11e3-8638-274e2c070003.png)

After
![before](https://f.cloud.github.com/assets/204609/1033282/1f299f58-0ef9-11e3-9f44-71c4d08c7909.png)

I have added tests for the new pullRight option.

I saw there is no test for 'appendWidgetTo' configuration option, so I tried to add it... but I failed.

I wrote the test in order to make them DRY. Let me know if you find them to complicated.
## Todo
- [ ] Add documentation for new feature. To bad the documentation is not included in the main branch, together with code.
- [ ] Fix test for appendWidgetTo
# How to try and test the changes

Check that pullRight configuration option make sense.

I was also thinking that instead of pull-right option, this can be implemented with an "extraCSSClasses" configuration options, and then pass the "pull-right" class and fix everthing else from custom CSS.

Create a time picker with `pullRight: true` option and check that it is right aligned and has the arrow on the right side.

Please check the test for appendWidgetTo and let me know what I did wrong and why the test is not passing.
It looks like it ignores the appendWidgetTo and appends to `.bootstrap-timepicker`

I can remove the test for appendWidgetTo and have this branch pass full test, but I prefer to have it written.

Thanks!
