### PR TITLE
Add dedicated trigger for dropdown.

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -38,7 +38,7 @@
       var self = this;
 
       if (this.$element.parent().hasClass('input-append') || this.$element.parent().hasClass('input-prepend')) {
-        this.$element.parent('.input-append, .input-prepend').find('.add-on').on({
+        this.$element.parent('.input-append, .input-prepend').find('.bootstrap-timepicker-trigger').on({
           'click.timepicker': $.proxy(this.showWidget, this)
         });
         this.$element.on({

--- a/less/timepicker.less
+++ b/less/timepicker.less
@@ -29,13 +29,8 @@
         }
     }
 
-    .add-on { 
+    .bootstrap-timepicker-trigger {
         cursor: pointer;
-        i {
-           display: inline-block;
-           width: 16px;
-           height: 16px;
-        }
     }
 }
 .bootstrap-timepicker-widget {

--- a/spec/js/TimepickerSpec.js
+++ b/spec/js/TimepickerSpec.js
@@ -364,7 +364,7 @@ describe('Timepicker feature', function() {
       hideEvents++;
     });
 
-    $input1.parents('div').find('.add-on').trigger('click');
+    $input1.parents('div').find('.bootstrap-timepicker-trigger').trigger('click');
     $('body').trigger('mousedown');
 
     expect(hideEvents).toBe(1);

--- a/spec/js/fixtures/timepicker.html
+++ b/spec/js/fixtures/timepicker.html
@@ -1,10 +1,10 @@
 <div class="input-append bootstrap-timepicker">
     <input id="timepicker1" type="text" class="input-small">
-    <span class="add-on"><i class="icon-time"></i></span>
+    <span class="add-on bootstrap-timepicker-trigger"><i class="icon-time"></i></span>
 </div>
 <div class="input-append bootstrap-timepicker">
     <input id="timepicker2" type="text" class="input-small">
-    <span class="add-on"><i class="icon-time"></i></span>
+    <span class="add-on bootstrap-timepicker-trigger"><i class="icon-time"></i></span>
 </div>
 <div class="bootstrap-timepicker">
     <input id="timepicker3" type="text" />


### PR DESCRIPTION
# Problem description

The picker assumes that any element with class 'add-on' inside a prepend append input field should be used as the trigger for the dropdown menu.

I feel that 'add-on' class should be left alone as "presentation" class, and the picker should use a dedicated "behavioural" class.
# Changes description

I have changed the picker to use "bootstrap-timepicker-trigger" class to select elements which should trigger the dropdown.

I have also remove all presentation rules from the LESS files, apart for cursor presentation.
I think that the picker should touch the presentation as little as possible and focus on behavior.
User can define they own custom CSS rules, as long as the picker sets the right classes.

The tests were updated to work with the new trigger
## To Do
- [ ] Update documentation. To bad documentation is not hosted in the same branch. This will need a separate pull request, once this change lands in master.
# How to try and test the changes

Use the following markup.

The "Start time" add-on should not trigger the picker... but only the icon add-on.

```
    <div
      class="input-prepend input-append bootstrap-timepicker">
      <span class="add-on">Start time</span>
      <input type="text"  size="8" placeholder="HH:MM:SS">
      <span class="add-on bootstrap-timepicker-trigger">
        <i class="icon icon-time"></i>
      </span>
    </div>
```

Thanks!
