### PR TITLE
highlightPrevUnit does not highlight minutes correctly if not showing meridian or seconds

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -419,7 +419,13 @@
     highlightPrevUnit: function() {
       switch (this.highlightedUnit) {
       case 'hour':
-        this.highlightMeridian();
+        if(this.showMeridian){
+          this.highlightMeridian();
+        } else if (this.showSeconds) {
+          this.highlightSecond();
+        } else {
+          this.highlightMinute();
+        }
         break;
       case 'minute':
         this.highlightHour();


### PR DESCRIPTION
resubmit #140 under gh-pages
