### PR TITLE
Update bootstrap-timepicker.js Added data api

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -1093,5 +1093,17 @@
   };
 
   $.fn.timepicker.Constructor = Timepicker;
+  
+  $(document).on(
+    'focus.timepicker.data-api click.timepicker.data-api',
+    '[data-provide="timepicker"]',
+    function(e){
+      var $this = $(this);
+      if ($this.data('timepicker')) return;
+      e.preventDefault();
+      // component click requires us to explicitly show it
+      $this.timepicker();
+    }
+  );
 
 })(jQuery, window, document);


### PR DESCRIPTION
As with bootstrap’s own plugins, datepicker provides a data-api that can be used to instantiate datepickers without the need for custom javascript. For most datepickers, simply set data-provide="timepicker" on the element you want to initialize, and it will be intialized lazily, in true bootstrap fashion.
