### PR TITLE
Fix 24h display when showMeridian is false.

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -319,11 +319,28 @@
     },
 
     getTime: function() {
+      var timestr;
       if (this.hour === '') {
         return '';
       }
 
-      return this.hour + ':' + (this.minute.toString().length === 1 ? '0' + this.minute : this.minute) + (this.showSeconds ? ':' + (this.second.toString().length === 1 ? '0' + this.second : this.second) : '') + (this.showMeridian ? ' ' + this.meridian : '');
+      timestr = this.paddedTime(this.hour) + ':' + this.paddedTime(this.minute, true);
+      if (this.showSeconds) {
+        timestr = timestr + ':' + this.paddedTime(this.second, true);
+      }
+      if (this.showMeridian) {
+        timestr = timestr + ' ' + this.meridian;
+      }
+      return timestr;
+    },
+
+    paddedTime: function(val, override) {
+      if (!this.showMeridian || override) {
+        // ensure that given value is padded with zeros
+        return ('0' + val).slice(-2);
+      } else {
+        return val;
+      }
     },
 
     hideWidget: function() {
@@ -937,9 +954,9 @@
         return;
       }
 
-      var hour = this.hour,
-          minute = this.minute.toString().length === 1 ? '0' + this.minute : this.minute,
-          second = this.second.toString().length === 1 ? '0' + this.second : this.second;
+      var hour = this.paddedTime(this.hour),
+          minute = this.paddedTime(this.minute, true),
+          second = this.paddedTime(this.second, true);
 
       if (this.showInputs) {
         this.$widget.find('input.bootstrap-timepicker-hour').val(hour);

--- a/spec/js/TimepickerSpec.js
+++ b/spec/js/TimepickerSpec.js
@@ -161,6 +161,14 @@ describe('Timepicker feature', function() {
     expect(tp2.$widget.find('.bootstrap-timepicker-meridian').val()).toBe('AM');
   });
 
+  it('should ensure that 24 hour widgets pad the hours on display', function() {
+    tp3.setTime('2:04:05');
+    expect($input3.val()).toBe('02:04:05');
+    expect(tp3.$widget.find('.bootstrap-timepicker-hour').val()).toBe('02');
+    expect(tp3.$widget.find('.bootstrap-timepicker-minute').val()).toBe('04');
+    expect(tp3.$widget.find('.bootstrap-timepicker-second').val()).toBe('05');
+  });
+
   it('should be able get & set the pickers time', function() {
     tp1.setTime('11:15 PM');
     expect(tp1.getTime()).toBe('11:15 PM');
@@ -180,7 +188,7 @@ describe('Timepicker feature', function() {
     tp1.setTime('1');
     expect(tp1.getTime()).toBe('1:00 AM');
     tp3.setTime('1');
-    expect(tp3.getTime()).toBe('1:00:00');
+    expect(tp3.getTime()).toBe('01:00:00');
 
     tp1.setTime('13');
     expect(tp1.getTime()).toBe('12:00 AM');
@@ -218,7 +226,7 @@ describe('Timepicker feature', function() {
     expect(tp3.getTime()).toBe('23:20:00', 'setTime with 2320 on tp3');
 
     tp3.setTime('0:00');
-    expect(tp3.getTime()).toBe('0:00:00', 'setTime with 0:00 on tp3');
+    expect(tp3.getTime()).toBe('00:00:00', 'setTime with 0:00 on tp3');
   });
 
   it('should update picker on blur', function() {


### PR DESCRIPTION
This pull request adds a simple padding method for use when showMeridian is false and elsewhere. I added one extra spec for testing. 24 hour times should now have double digits on display. This should fix #208.

I also noted that the pull request #203 did not actually set the display, only the underlying values. In my opinion, this pull request has a cleaner and easier to read solution.
