### PR TITLE
Added support for a timeSeparator option

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -807,7 +807,7 @@
           }
         } else {
           if (hour >= 24) {
-            hour = 23;
+            hour = 0;
           } else if (hour < 0) {
             hour = 0;
           }

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -338,7 +338,7 @@
       return sb.join('');
     },
     
-    getIso8601Time : function() {
+    getIso8601 : function() {
         if (this.hour === '') {
           return '';
         }
@@ -930,7 +930,7 @@
     	this.$element.trigger({
             'type': eventName,
             'time': {
-              'iso8601' : this.getIso8601Time(),
+              'iso8601' : this.getIso8601(),
               'value': this.getTime(),
               'hours': this.hour,
               'minutes': this.minute,
@@ -1071,12 +1071,15 @@
       }
     }
   };
-
+  // could make same stuff to allow only some (public) methods
+  var getters = {'getTime':1, 'getIso8601':1};
   //TIMEPICKER PLUGIN DEFINITION
   $.fn.timepicker = function(option) {
     var args = Array.apply(null, arguments);
     args.shift();
-    return this.each(function() {
+    // potential return values
+    var ret = [];
+    this.each(function() {	
       var $this = $(this),
         data = $this.data('timepicker'),
         options = typeof option === 'object' && option;
@@ -1086,9 +1089,16 @@
       }
 
       if (typeof option === 'string') {
-        data[option].apply(data, args);
+    	if(typeof data[option]=='undefined') throw 'Unknown method : ' + option;
+        var res = data[option].apply(data, args);
+        ret.push(res);
       }
     });
+    // If is a getter return first value 
+    // otherwise std chaining.
+    // Could return the array (all) but for what ?
+    // Also there is always at least one item, right ?
+    return getters[option] ? ret[0] : this;
   };
 
   $.fn.timepicker.defaults = {

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -36,6 +36,7 @@
     this.pmDesignator = input.data('pm') ? input.data('pm') : options.pmDesignator;
     this.twoDigitsHour = input.data('two-digits-hour') ? input.data('two-digits-hour') : options.twoDigitsHour;
     this.submitMode = options.submitMode;
+    this.suffix = input.data('suffix') ? input.data('suffix') : options.suffix; 
     this._init();
   };
 
@@ -350,6 +351,7 @@
           sb.push(this.pad(this.second));
       }
       if (this.showMeridian) sb.push(this.meridianSeparator + this.meridian);
+      sb.push(this.suffix);
       return sb.join('');
     },
     
@@ -660,7 +662,10 @@
 
       if (this.orientation.x !== 'auto') {
         // Should prob be this.$widget #192 #181
-        this.picker.addClass('datepicker-orient-' + this.orientation.x);
+    	// 20140523 now also https://github.com/jdewit/bootstrap-timepicker/pull/229 says same
+    	// I trust them ;-)
+        // this.picker.addClass('datepicker-orient-' + this.orientation.x);
+        this.$widget.addClass('timepicker-orient-' + this.orientation.x);
         if (this.orientation.x === 'right') {
           left -= widgetWidth - width;
         }
@@ -953,6 +958,7 @@
               'minutes': this.minute,
               'seconds': this.second,
               'meridian': this.meridian,
+              'suffix': this.suffix,
               'am' : this.showMeridian ? this.meridian === this.amDesignator : undefined,
             }
           });
@@ -1139,6 +1145,7 @@
     twoDigitsHour : false,
     timeSeparator : ':',
     meridianSeparator : ' ', // only sq, sq_AL (Albanian) has '.'
+    suffix : '', // only th
     amDesignator : 'AM',
     pmDesignator : 'PM',
     submitMode : 'default', // 'default' (untouched display value) or 'iso' (ISO with seconds) or 'iso-auto' (ISO possibly without seconds)

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -29,7 +29,7 @@
     this.template = options.template;
     this.appendWidgetTo = options.appendWidgetTo;
     this.showWidgetOnAddonClick = options.showWidgetOnAddonClick;
-
+    this.timeSeparator = options.timeSeparator;
     this._init();
   };
 
@@ -269,10 +269,10 @@
          '</tr>'+
          '<tr>'+
            '<td>'+ hourTemplate +'</td> '+
-           '<td class="separator">:</td>'+
+           '<td class="separator">' + this.timeSeparator + '</td>'+
            '<td>'+ minuteTemplate +'</td> '+
            (this.showSeconds ?
-            '<td class="separator">:</td>'+
+            '<td class="separator">' + this.timeSeparator + '</td>'+
             '<td>'+ secondTemplate +'</td>'
            : '') +
            (this.showMeridian ?
@@ -323,7 +323,7 @@
         return '';
       }
 
-      return this.hour + ':' + (this.minute.toString().length === 1 ? '0' + this.minute : this.minute) + (this.showSeconds ? ':' + (this.second.toString().length === 1 ? '0' + this.second : this.second) : '') + (this.showMeridian ? ' ' + this.meridian : '');
+      return this.hour + this.timeSeparator + (this.minute.toString().length === 1 ? '0' + this.minute : this.minute) + (this.showSeconds ? this.timeSeparator + (this.second.toString().length === 1 ? '0' + this.second : this.second) : '') + (this.showMeridian ? ' ' + this.meridian : '');
     },
 
     hideWidget: function() {
@@ -763,10 +763,9 @@
         } else {
           meridian = 'AM';
         }
-
-        time = time.replace(/[^0-9\:]/g, '');
-
-        timeArray = time.split(':');
+        // Don't know how to include dynamically a char do both [.:]
+        time = time.replace(/[^0-9\:\.]/g, '');
+        timeArray = time.split(this.timeSeparator);
 
         hour = timeArray[0] ? timeArray[0].toString() : timeArray.toString();
         minute = timeArray[1] ? timeArray[1].toString() : '';
@@ -887,7 +886,7 @@
         if (this.defaultTime) {
           this.setDefaultTime(this.defaultTime);
         } else {
-          this.setTime('0:0:0');
+          this.setTime('0' + this.timeSeparator + '0' + this.timeSeparator + '0');
         }
       }
 
@@ -969,9 +968,9 @@
         return;
       }
 
-      var t = this.$widget.find('input.bootstrap-timepicker-hour').val() + ':' +
+      var t = this.$widget.find('input.bootstrap-timepicker-hour').val() + this.timeSeparator +
               this.$widget.find('input.bootstrap-timepicker-minute').val() +
-              (this.showSeconds ? ':' + this.$widget.find('input.bootstrap-timepicker-second').val() : '') +
+              (this.showSeconds ? this.timeSeparator + this.$widget.find('input.bootstrap-timepicker-second').val() : '') +
               (this.showMeridian ? this.$widget.find('input.bootstrap-timepicker-meridian').val() : '')
       ;
 
@@ -1089,7 +1088,8 @@
     showMeridian: true,
     template: 'dropdown',
     appendWidgetTo: 'body',
-    showWidgetOnAddonClick: true
+    showWidgetOnAddonClick: true,
+    timeSeparator : ':'
   };
 
   $.fn.timepicker.Constructor = Timepicker;

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -33,6 +33,7 @@
     this.timeSeparator = input.data('time-separator') ? input.data('time-separator') : options.timeSeparator;
     this.amDesignator = input.data('am') ? input.data('am') : options.amDesignator;
     this.pmDesignator = input.data('pm') ? input.data('pm') : options.pmDesignator;
+    this.twoDigitsHour = input.data('two-digits-hour') ? input.data('two-digits-hour') : options.twoDigitsHour;
     this._init();
   };
 
@@ -325,8 +326,13 @@
       if (this.hour === '') {
         return '';
       }
-
-      return this.hour + this.timeSeparator + (this.minute.toString().length === 1 ? '0' + this.minute : this.minute) + (this.showSeconds ? this.timeSeparator + (this.second.toString().length === 1 ? '0' + this.second : this.second) : '') + (this.showMeridian ? ' ' + this.meridian : '');
+      return this.getFormattedHour() + this.timeSeparator + (this.minute.toString().length === 1 ? '0' + this.minute : this.minute) + (this.showSeconds ? this.timeSeparator + (this.second.toString().length === 1 ? '0' + this.second : this.second) : '') + (this.showMeridian ? ' ' + this.meridian : '');
+    },
+    
+    getFormattedHour : function() {
+    	var h = "" + this.hour;
+        if (h.length==1 && this.twoDigitsHour===true) h = '0' + h;
+        return h;
     },
 
     hideWidget: function() {
@@ -437,11 +443,9 @@
 
 			if ($element.setSelectionRange) {
 				setTimeout(function() {
-          if (self.hour < 10) {
-            $element.setSelectionRange(0,1);
-          } else {
-            $element.setSelectionRange(0,2);
-          }
+		  var fh = self.getFormattedHour();
+          $element.setSelectionRange(0,fh.length);
+          
 				}, 0);
 			}
     },
@@ -454,11 +458,9 @@
 
 			if ($element.setSelectionRange) {
 				setTimeout(function() {
-          if (self.hour < 10) {
-            $element.setSelectionRange(2,4);
-          } else {
-            $element.setSelectionRange(3,5);
-          }
+			var fh = self.getFormattedHour();
+			var p = 1 + fh.length;           
+            $element.setSelectionRange(p,p+2);
 				}, 0);
 			}
     },
@@ -471,11 +473,9 @@
 
 			if ($element.setSelectionRange) {
 				setTimeout(function() {
-          if (self.hour < 10) {
-            $element.setSelectionRange(5,7);
-          } else {
-            $element.setSelectionRange(6,8);
-          }
+          var fh = self.getFormattedHour();
+          var p = 4+fh.length;
+          $element.setSelectionRange(p,p+2);
 				}, 0);
 			}
     },
@@ -488,10 +488,11 @@
 
 			if ($element.setSelectionRange) {
 				var start;
-				if (this.showSeconds) {
-					start = self.hour < 10 ? 8 : 9;
+				var fh = self.getFormattedHour();
+		        if (this.showSeconds) {
+					start = 7 + fh.length;
 				} else {
-					start = self.hour < 10 ? 5 : 6;
+					start = 4 + fh.length;
 				}
 				 
 					setTimeout(function() {
@@ -731,7 +732,6 @@
         this.clear();
         return;
       }
-
       var timeArray,
           hour,
           minute,
@@ -1090,6 +1090,7 @@
     template: 'dropdown',
     appendWidgetTo: 'body',
     showWidgetOnAddonClick: true,
+    twoDigitsHour : false,
     timeSeparator : ':',
     amDesignator : 'AM',
     pmDesignator : 'PM',

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -26,11 +26,11 @@
     this.secondStep = options.secondStep;
     this.showInputs = options.showInputs;
     this.showMeridian = typeof input.data('meridian')!='undefined' ? input.data('meridian') : options.showMeridian;
-    this.showSeconds = typeof input.data('show-seconds')!='undefined' ? input.data('show-seconds') : options.showSeconds;
+    this.showSeconds = options.showSeconds;
     this.template = options.template;
     this.appendWidgetTo = options.appendWidgetTo;
     this.showWidgetOnAddonClick = options.showWidgetOnAddonClick;
-    this.timeSeparator = input.data('time-separator') ? input.data('time-separator') : options.timeSeparator;
+    this.timeSeparator = options.timeSeparator;
     this.amDesignator = input.data('am') ? input.data('am') : options.amDesignator;
     this.pmDesignator = input.data('pm') ? input.data('pm') : options.pmDesignator;
     this.twoDigitsHour = input.data('two-digits-hour') ? input.data('two-digits-hour') : options.twoDigitsHour;
@@ -1085,7 +1085,9 @@
         options = typeof option === 'object' && option;
 
       if (!data) {
-        $this.data('timepicker', (data = new Timepicker(this, $.extend({}, $.fn.timepicker.defaults, options, $(this).data()))));
+    	// use data- attributes as config
+    	var conf = $.extend({}, $.fn.timepicker.defaults, options, $(this).data());
+    	$this.data('timepicker', (data = new Timepicker(this, conf)));
       }
 
       if (typeof option === 'string') {

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -802,7 +802,8 @@
           if (hour < 1) {
             hour = 1;
           } else if (hour > 12) {
-            hour = 12;
+            meridian = this.pmDesignator;
+            hour %= 12;
           }
         } else {
           if (hour >= 24) {

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -756,12 +756,13 @@
           }
         }
       } else {
-        if (time.match(/p/i) !== null) {
+    	  if (time.match(new RegExp(this.pmDesignator, "i")) !== null) {
           meridian = this.pmDesignator;
         } else {
           meridian = this.amDesignator;
         }
-        // Don't know how to include dynamically a char do both [.:]
+
+        // Remove both allowed separators [.:]
         time = time.replace(/[^0-9\:\.]/g, '');
         timeArray = time.split(this.timeSeparator);
 

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -935,7 +935,8 @@
               'hours': this.hour,
               'minutes': this.minute,
               'seconds': this.second,
-              'meridian': this.meridian
+              'meridian': this.meridian,
+              'am' : this.showMeridian ? this.meridian === this.amDesignator : undefined,
             }
           });
     },

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -14,7 +14,8 @@
   // TIMEPICKER PUBLIC CLASS DEFINITION
   var Timepicker = function(element, options) {
     this.widget = '';
-    this.$element = $(element);
+    var input = $(element);
+    this.$element = input;
     this.defaultTime = options.defaultTime;
     this.disableFocus = options.disableFocus;
     this.disableMousewheel = options.disableMousewheel;
@@ -24,15 +25,14 @@
     this.orientation = options.orientation;
     this.secondStep = options.secondStep;
     this.showInputs = options.showInputs;
-    this.showMeridian = options.showMeridian;
+    this.showMeridian = typeof input.data('meridian')!='undefined' ? input.data('meridian') : options.showMeridian;
     this.showSeconds = options.showSeconds;
     this.template = options.template;
     this.appendWidgetTo = options.appendWidgetTo;
     this.showWidgetOnAddonClick = options.showWidgetOnAddonClick;
-    this.timeSeparator = options.timeSeparator;
-    this.amDesignator = options.amDesignator ? options.amDesignator : 'AM';
-    this.pmDesignator = options.pmDesignator ? options.pmDesignator : 'PM';
-    
+    this.timeSeparator = input.data('time-separator') ? input.data('time-separator') : options.timeSeparator;
+    this.amDesignator = input.data('am') ? input.data('am') : options.amDesignator;
+    this.pmDesignator = input.data('pm') ? input.data('pm') : options.pmDesignator;
     this._init();
   };
 
@@ -620,6 +620,7 @@
       this.$widget.removeClass('timepicker-orient-top timepicker-orient-bottom timepicker-orient-right timepicker-orient-left');
 
       if (this.orientation.x !== 'auto') {
+        // Should prob be this.$widget #192 #181
         this.picker.addClass('datepicker-orient-' + this.orientation.x);
         if (this.orientation.x === 'right') {
           left -= widgetWidth - width;
@@ -801,7 +802,7 @@
         if (this.showMeridian) {
           if (hour <= 0 || hour >= 24) {
             meridian = this.amDesignator;
-            hour = 0;
+            hour = 12;
           } else if (hour > 12) {
             meridian = this.pmDesignator;
             hour %= 12;

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -30,6 +30,9 @@
     this.appendWidgetTo = options.appendWidgetTo;
     this.showWidgetOnAddonClick = options.showWidgetOnAddonClick;
     this.timeSeparator = options.timeSeparator;
+    this.amDesignator = options.amDesignator ? options.amDesignator : 'AM';
+    this.pmDesignator = options.pmDesignator ? options.pmDesignator : 'PM';
+    
     this._init();
   };
 
@@ -299,7 +302,7 @@
       case 'modal':
         template = '<div class="bootstrap-timepicker-widget modal hide fade in" data-backdrop="'+ (this.modalBackdrop ? 'true' : 'false') +'">'+
           '<div class="modal-header">'+
-            '<a href="#" class="close" data-dismiss="modal">×</a>'+
+            '<a href="#" class="close" data-dismiss="modal">&times;</a>'+
             '<h3>Pick a Time</h3>'+
           '</div>'+
           '<div class="modal-content">'+
@@ -484,23 +487,17 @@
       this.highlightedUnit = 'meridian';
 
 			if ($element.setSelectionRange) {
+				var start;
 				if (this.showSeconds) {
-					setTimeout(function() {
-            if (self.hour < 10) {
-              $element.setSelectionRange(8,10);
-            } else {
-              $element.setSelectionRange(9,11);
-            }
-					}, 0);
+					start = self.hour < 10 ? 8 : 9;
 				} else {
-					setTimeout(function() {
-            if (self.hour < 10) {
-              $element.setSelectionRange(5,7);
-            } else {
-              $element.setSelectionRange(6,8);
-            }
-					}, 0);
+					start = self.hour < 10 ? 5 : 6;
 				}
+				 
+					setTimeout(function() {
+				$element.setSelectionRange(start,start+self.meridian.length);
+					}, 0);
+				
 			}
     },
 
@@ -677,7 +674,7 @@
             hours = dTime.getHours(),
             minutes = dTime.getMinutes(),
             seconds = dTime.getSeconds(),
-            meridian = 'AM';
+            meridian = this.amDesignator;
 
           if (seconds !== 0) {
             seconds = Math.ceil(dTime.getSeconds() / this.secondStep) * this.secondStep;
@@ -702,9 +699,9 @@
               if (hours > 12) {
                 hours = hours - 12;
               }
-              meridian = 'PM';
+              meridian = this.pmDesignator;
             } else {
-              meridian = 'AM';
+              meridian = this.amDesignator;
             }
           }
 
@@ -719,7 +716,7 @@
           this.hour = 0;
           this.minute = 0;
           this.second = 0;
-          this.meridian = 'AM';
+          this.meridian = this.amDesignator;
         } else {
           this.setTime(defaultTime);
         }
@@ -747,21 +744,21 @@
         second  = time.getSeconds();
 
         if (this.showMeridian){
-          meridian = 'AM';
+          meridian = this.amDesignator;
           if (hour > 12){
-            meridian = 'PM';
+            meridian = this.pmDesignator;
             hour = hour % 12;
           }
 
           if (hour === 12){
-            meridian = 'PM';
+            meridian = this.pmDesignator;
           }
         }
       } else {
         if (time.match(/p/i) !== null) {
-          meridian = 'PM';
+          meridian = this.pmDesignator;
         } else {
-          meridian = 'AM';
+          meridian = this.amDesignator;
         }
         // Don't know how to include dynamically a char do both [.:]
         time = time.replace(/[^0-9\:\.]/g, '');
@@ -813,7 +810,7 @@
           } else if (hour < 0) {
             hour = 0;
           }
-          if (hour < 13 && meridian === 'PM') {
+          if (hour < 13 && meridian === this.pmDesignator) {
             hour = hour + 12;
           }
         }
@@ -902,7 +899,7 @@
     },
 
     toggleMeridian: function() {
-      this.meridian = this.meridian === 'AM' ? 'PM' : 'AM';
+      this.meridian = this.meridian === this.amDesignator ? this.pmDesignator : this.amDesignator;
     },
 
     update: function(ignoreWidget) {
@@ -1089,7 +1086,9 @@
     template: 'dropdown',
     appendWidgetTo: 'body',
     showWidgetOnAddonClick: true,
-    timeSeparator : ':'
+    timeSeparator : ':',
+    amDesignator : 'AM',
+    pmDesignator : 'PM',
   };
 
   $.fn.timepicker.Constructor = Timepicker;

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -799,8 +799,9 @@
         }
 
         if (this.showMeridian) {
-          if (hour < 1) {
-            hour = 1;
+          if (hour <= 0 || hour >= 24) {
+            meridian = this.amDesignator;
+            hour = 0;
           } else if (hour > 12) {
             meridian = this.pmDesignator;
             hour %= 12;

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -76,7 +76,7 @@
         }
       }
       this.$element.parents('form').on({
-          'submit.timepicker': $.proxy(this.onsubmit, this),
+          'submit.timepicker': $.proxy(this.onsubmit, this)
       })
 
       if (this.template !== false) {
@@ -959,7 +959,7 @@
               'seconds': this.second,
               'meridian': this.meridian,
               'suffix': this.suffix,
-              'am' : this.showMeridian ? this.meridian === this.amDesignator : undefined,
+              'am' : this.showMeridian ? this.meridian === this.amDesignator : undefined
             }
           });
     },
@@ -1148,7 +1148,7 @@
     suffix : '', // only th
     amDesignator : 'AM',
     pmDesignator : 'PM',
-    submitMode : 'default', // 'default' (untouched display value) or 'iso' (ISO with seconds) or 'iso-auto' (ISO possibly without seconds)
+    submitMode : 'default' // 'default' (untouched display value) or 'iso' (ISO with seconds) or 'iso-auto' (ISO possibly without seconds)
   };
 
   $.fn.timepicker.Constructor = Timepicker;

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -339,18 +339,8 @@
       if (this.isOpen === false) {
         return;
       }
-
-      this.$element.trigger({
-        'type': 'hide.timepicker',
-        'time': {
-          'value': this.getTime(),
-          'hours': this.hour,
-          'minutes': this.minute,
-          'seconds': this.second,
-          'meridian': this.meridian
-        }
-      });
-
+      this.raiseTimeEvent('hide.timepicker');
+      
       if (this.template === 'modal' && this.$widget.modal) {
         this.$widget.modal('hide');
       } else {
@@ -865,17 +855,7 @@
           self.hideWidget();
         }
       });
-
-      this.$element.trigger({
-        'type': 'show.timepicker',
-        'time': {
-          'value': this.getTime(),
-          'hours': this.hour,
-          'minutes': this.minute,
-          'seconds': this.second,
-          'meridian': this.meridian
-        }
-      });
+      this.raiseTimeEvent('show.timepicker');
 
       this.place();
       if (this.disableFocus) {
@@ -911,17 +891,21 @@
       if (!ignoreWidget) {
         this.updateWidget();
       }
-
-      this.$element.trigger({
-        'type': 'changeTime.timepicker',
-        'time': {
-          'value': this.getTime(),
-          'hours': this.hour,
-          'minutes': this.minute,
-          'seconds': this.second,
-          'meridian': this.meridian
-        }
-      });
+      this.raiseTimeEvent('changeTime.timepicker');
+      
+    },
+    
+    raiseTimeEvent : function(eventName) {
+    	this.$element.trigger({
+            'type': eventName,
+            'time': {
+              'value': this.getTime(),
+              'hours': this.hour,
+              'minutes': this.minute,
+              'seconds': this.second,
+              'meridian': this.meridian
+            }
+          });
     },
 
     updateElement: function() {

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -326,15 +326,46 @@
       if (this.hour === '') {
         return '';
       }
-      return this.getFormattedHour() + this.timeSeparator + (this.minute.toString().length === 1 ? '0' + this.minute : this.minute) + (this.showSeconds ? this.timeSeparator + (this.second.toString().length === 1 ? '0' + this.second : this.second) : '') + (this.showMeridian ? ' ' + this.meridian : '');
+      var sb = [];
+      sb.push(this.getFormattedHour());
+      sb.push(this.timeSeparator);
+      sb.push(this.pad(this.minute));
+      if (this.showSeconds ) {
+          sb.push(this.timeSeparator);
+          sb.push(this.pad(this.second));
+      }
+      if (this.showMeridian) sb.push(' ' + this.meridian);
+      return sb.join('');
     },
+    
+    getIso8601Time : function() {
+        if (this.hour === '') {
+          return '';
+        }
+        var sb = [];
+        // not getFormattedHour
+        sb.push(this.pad(this.hour));
+        sb.push(this.timeSeparator);
+        sb.push(this.pad(this.minute));
+        sb.push(this.timeSeparator);
+        sb.push(this.pad(this.second));
+        return sb.join('');
+     },
     
     getFormattedHour : function() {
     	var h = "" + this.hour;
-        if (h.length==1 && this.twoDigitsHour===true) h = '0' + h;
-        return h;
+    	// careful here must go out string
+        return this.pad(h, !this.twoDigitsHour);
     },
-
+    
+    
+    // Takes a variant and outputs a string,
+    // use [ignore=true] to just convert
+    pad : function(v, ignore) {
+    	var f = "" + v;
+        return !ignore && f.length == 1 ? '0' + f : f;
+    },
+    
     hideWidget: function() {
       if (this.isOpen === false) {
         return;
@@ -899,6 +930,7 @@
     	this.$element.trigger({
             'type': eventName,
             'time': {
+              'iso8601' : this.getIso8601Time(),
               'value': this.getTime(),
               'hours': this.hour,
               'minutes': this.minute,

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -26,7 +26,7 @@
     this.secondStep = options.secondStep;
     this.showInputs = options.showInputs;
     this.showMeridian = typeof input.data('meridian')!='undefined' ? input.data('meridian') : options.showMeridian;
-    this.showSeconds = options.showSeconds;
+    this.showSeconds = typeof input.data('show-seconds')!='undefined' ? input.data('show-seconds') : options.showSeconds;
     this.template = options.template;
     this.appendWidgetTo = options.appendWidgetTo;
     this.showWidgetOnAddonClick = options.showWidgetOnAddonClick;

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -31,9 +31,11 @@
     this.appendWidgetTo = options.appendWidgetTo;
     this.showWidgetOnAddonClick = options.showWidgetOnAddonClick;
     this.timeSeparator = options.timeSeparator;
+    this.meridianSeparator = options.meridianSeparator;
     this.amDesignator = input.data('am') ? input.data('am') : options.amDesignator;
     this.pmDesignator = input.data('pm') ? input.data('pm') : options.pmDesignator;
     this.twoDigitsHour = input.data('two-digits-hour') ? input.data('two-digits-hour') : options.twoDigitsHour;
+    this.submitMode = options.submitMode;
     this._init();
   };
 
@@ -72,6 +74,9 @@
           });
         }
       }
+      this.$element.parents('form').on({
+          'submit.timepicker': $.proxy(this.onsubmit, this),
+      })
 
       if (this.template !== false) {
         this.$widget = $(this.getTemplate()).on('click', $.proxy(this.widgetClick, this));
@@ -92,6 +97,16 @@
       this.setDefaultTime(this.defaultTime);
     },
 
+    onsubmit : function(e) {
+    	var sm = this.submitMode;
+    	if (sm=='default') {
+    		// do nothing
+    	} else if (sm == 'iso' || sm == 'iso8601') {
+    		this.$element.val(this.getIso8601());
+        } else {
+        	this.$element.val(this.getIso8601(true));
+        }
+    },
     blurElement: function() {
       this.highlightedUnit = null;
       this.updateFromElementVal();
@@ -334,11 +349,11 @@
           sb.push(this.timeSeparator);
           sb.push(this.pad(this.second));
       }
-      if (this.showMeridian) sb.push(' ' + this.meridian);
+      if (this.showMeridian) sb.push(this.meridianSeparator + this.meridian);
       return sb.join('');
     },
     
-    getIso8601 : function() {
+    getIso8601 : function(optionalSeconds) {
         if (this.hour === '') {
           return '';
         }
@@ -347,8 +362,10 @@
         sb.push(this.pad(this.hour));
         sb.push(this.timeSeparator);
         sb.push(this.pad(this.minute));
-        sb.push(this.timeSeparator);
-        sb.push(this.pad(this.second));
+        if (!optionalSeconds || this.showSeconds) {
+	        sb.push(this.timeSeparator);
+	        sb.push(this.pad(this.second));
+        }
         return sb.join('');
      },
     
@@ -1121,8 +1138,10 @@
     showWidgetOnAddonClick: true,
     twoDigitsHour : false,
     timeSeparator : ':',
+    meridianSeparator : ' ', // only sq, sq_AL (Albanian) has '.'
     amDesignator : 'AM',
     pmDesignator : 'PM',
+    submitMode : 'default', // 'default' (untouched display value) or 'iso' (ISO with seconds) or 'iso-auto' (ISO possibly without seconds)
   };
 
   $.fn.timepicker.Constructor = Timepicker;


### PR DESCRIPTION
Looks like is working, can change ':' with dot '.'. For me is useful to integrate with java locales
At line 766 don't know syntax to include separator dynamically in RegEx however there are only two separators in all java locales: ':' and '.'. Next step could be similar work for AM/PM symbol (eg: Arabic م Greek μμ) and (harder perhaps) AM/PM before or after time, in Chinese for example is before 下午9:21
