### PR TITLE
Remove errant / from opening div tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,7 +349,7 @@ title: Timepicker for Twitter Bootstrap
         <h3>Data Attributes</h3>
         <p>Configuration options can also be set with the use of data attributes. </p>
 <pre class="prettyprint linenums">
-  &lt;div class="bootstrap-timepicker"/&gt;&lt;input id="timepicker" data-template="modal" data-minute-step="1" data-modal-backdrop="true" type="text"/&gt;&lt;/div&gt;
+  &lt;div class="bootstrap-timepicker"&gt;&lt;input id="timepicker" data-template="modal" data-minute-step="1" data-modal-backdrop="true" type="text"/&gt;&lt;/div&gt;
 </pre>
     </div>
     <hr>


### PR DESCRIPTION
I was reading through the documentation and noticed `<div class="bootstrap-timepicker"/>` on the page, which was clearly not intended.
