### PR TITLE
2-digit hour

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -29,7 +29,7 @@
     this.template = options.template;
     this.appendWidgetTo = options.appendWidgetTo;
     this.showWidgetOnAddonClick = options.showWidgetOnAddonClick;
-
+    this.hourTwoDigits = options.hourTwoDigits;
     this._init();
   };
 
@@ -323,7 +323,7 @@
         return '';
       }
 
-      return this.hour + ':' + (this.minute.toString().length === 1 ? '0' + this.minute : this.minute) + (this.showSeconds ? ':' + (this.second.toString().length === 1 ? '0' + this.second : this.second) : '') + (this.showMeridian ? ' ' + this.meridian : '');
+      return ((this.hour.toString().length === 1 && this.hourTwoDigits)? '0' + this.hour : this.hour)  + ':' + (this.minute.toString().length === 1 ? '0' + this.minute : this.minute) + (this.showSeconds ? ':' + (this.second.toString().length === 1 ? '0' + this.second : this.second) : '') + (this.showMeridian ? ' ' + this.meridian : '');
     },
 
     hideWidget: function() {
@@ -1089,7 +1089,8 @@
     showMeridian: true,
     template: 'dropdown',
     appendWidgetTo: 'body',
-    showWidgetOnAddonClick: true
+    showWidgetOnAddonClick: true,
+    hourTwoDigits: false,
   };
 
   $.fn.timepicker.Constructor = Timepicker;


### PR DESCRIPTION
I tried to use bootstrap-timepicker  with Masked Input Plugin but I had no success because the hour should be returned always with two digits, otherwise it cannot be validated by mask input, so the value it is canceled. All the time when the user clicks the input, the value it is reset to empty and has a strange behavior. I did not find any settings in the timepicker to force to return always 2 digits for the hour. So I decided to make changes in the code. 
This commit contains the change, a new option "hourTwoDigits" in the settings, which is default set to false, to not affect the behavior for those who already implemented timepicker.
 $('#timepicker').timepicker({
        hourTwoDigits:true
});
