### PR TITLE
Changed Travis badge to get only gh-pages status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Timepicker for Twitter Bootstrap
 =======
 
-Timepicker for Twitter Bootstrap [![Build Status](https://secure.travis-ci.org/jdewit/bootstrap-timepicker.png)](http://travis-ci.org/jdewit/bootstrap-timepicker)
+Timepicker for Twitter Bootstrap [![Build Status](https://travis-ci.org/jdewit/bootstrap-timepicker.svg?branch=gh-pages)](https://travis-ci.org/jdewit/bootstrap-timepicker)
 ------------------------------------
 
 A simple timepicker component for Twitter Bootstrap.


### PR DESCRIPTION
There's no reason to show the status from other branches in the README, the badge should reflect the current state of the primary branch (in this case, gh-pages)
