### PR TITLE
add support for latest bootstrap versions as well

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,8 +11,8 @@
         "less/bootstrap-timepicker.less"
     ],
     "dependencies": {
-        "bootstrap": "~3.0",
-        "jquery": "~2.0"
+        "bootstrap": ">=3.0",
+        "jquery": ">=2.0"
     },
     "devDependencies": {
         "autotype": "https://raw.github.com/mmonteleone/jquery.autotype/master/jquery.autotype.js"


### PR DESCRIPTION
this will reduce the chance of bower dependency confusions. 
