### PR TITLE
Timepicker will now close its widget when tab out

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ to take care of longstanding issues. Otherwise, fork away or use some of the oth
 Installation
 ============
 
-This project is registered as a <a href="http://bower.io">Bower</a> package, and can be insalled with the following command:
+This project is registered as a <a href="http://bower.io">Bower</a> package, and can be installed with the following command:
 
 ```bash
 $ bower install bootstrap-timepicker

--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -174,10 +174,16 @@
       case 9: //tab
         if (e.shiftKey) {
           if (this.highlightedUnit === 'hour') {
+            if (this.isOpen) {
+              this.hideWidget();
+            }
             break;
           }
           this.highlightPrevUnit();
         } else if ((this.showMeridian && this.highlightedUnit === 'meridian') || (this.showSeconds && this.highlightedUnit === 'second') || (!this.showMeridian && !this.showSeconds && this.highlightedUnit ==='minute')) {
+          if (this.isOpen) {
+            this.hideWidget();
+          }
           break;
         } else {
           this.highlightNextUnit();

--- a/spec/js/KeyboardEventsSpec.js
+++ b/spec/js/KeyboardEventsSpec.js
@@ -261,4 +261,42 @@ describe('Keyboard events feature', function() {
     $input3.autotype('{{back}}{{back}}{{back}}{{back}}{{back}}{{back}}{{back}}{{back}}25:60:60{{tab}}');
     expect(tp3.getTime()).toBe('23:59:59');
   });
+
+  it('should close timepicker widget on TAB out of field', function() {
+    $input1.trigger('focus');
+    tp1.showWidget();
+    expect(tp1.isOpen).toBe(true);
+    expect(tp1.highlightedUnit).toBe('hour');
+
+    $input1.autotype('{{tab}}');
+    expect(tp1.highlightedUnit).toBe('minute');
+
+    $input1.autotype('{{tab}}');
+    expect(tp1.highlightedUnit).toBe('meridian');
+
+    $input1.autotype('{{tab}}');
+    expect(tp1.isOpen).toBe(false);
+  });
+
+  it('should close timepicker widget on SHIFT+TAB out of field', function() {
+    $input1.trigger('focus');
+    tp1.showWidget();
+    expect(tp1.isOpen).toBe(true);
+    expect(tp1.highlightedUnit).toBe('hour');
+
+    $input1.autotype('{{tab}}');
+    expect(tp1.highlightedUnit).toBe('minute');
+
+    $input1.autotype('{{tab}}');
+    expect(tp1.highlightedUnit).toBe('meridian');
+
+    $input1.autotype('{{shift}}{{tab}}{{/shift}}');
+    expect(tp1.highlightedUnit).toBe('minute');
+
+    $input1.autotype('{{shift}}{{tab}}{{/shift}}');
+    expect(tp1.highlightedUnit).toBe('hour');
+
+    $input1.autotype('{{shift}}{{tab}}{{/shift}}');
+    expect(tp1.isOpen).toBe(false);
+  });
 });


### PR DESCRIPTION
If the timepicker widget is showing when the user
tabs out of the input control (either via
SHIFT+TAB or just TAB), the widget was still
showing on the screen.  This commit fixes it so
that the widget will close if it is open at the
time the user tabs out.
