### PR TITLE
correct bower.json reference to timepicker.less

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     },
     "main": [
         "js/bootstrap-timepicker.js",
-        "less/bootstrap-timepicker.less"
+        "less/timepicker.less"
     ],
     "dependencies": {
         "bootstrap": "~3.0",


### PR DESCRIPTION
Apparently, for users of main-bower-files, it couldn't find the less
file. Thanks @carlosble.

Fix #300
