### PR TITLE
Only publish interesting files to npm (discussion started in #302)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "email": "joris.w.dewit@gmail.com",
     "url": "http://jorisdewit.ca"
   },
-  "main": "js/bootstrap-timepicker",
+  "main": "js/bootstrap-timepicker.js",
+  "files": ["js", "css", "less"],
   "repository": {
     "type": "git",
     "url": "git://github.com/jdewit/bootstrap-timepicker"


### PR DESCRIPTION
I have added the `files` attribute to the package.json.

With this configuration, `npm publish` will publish all files in the "js", "css" and "less" directories. I think those are the files that are interesting for people that install this library through npm.

It also by default installs the CHANGELOG.md, LICENSE and README.md files.

I did not include any other files because to me it looks like those are files for the website or something (assets, index.html etc).

If you run `grunt compile` and `npm publish` with this configuration, everything should go OK.

@mrhota do you agree with this setup, or do you want me to add some more files to the npm package?
