### PR TITLE
decrementMinute - added round to next step for when initial value is not a multiple of the step.

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -147,7 +147,12 @@
       if (step) {
         newVal = this.minute - step;
       } else {
-        newVal = this.minute - this.minuteStep;
+        if(this.minuteStep > 0 && (this.minute % this.minuteStep) > 0) {
+          newVal = this.minute - (this.minute % this.minuteStep);
+        }
+        else {
+          newVal = this.minute - this.minuteStep;
+        }
       }
 
       if (newVal < 0) {

--- a/spec/js/TimepickerSpec.js
+++ b/spec/js/TimepickerSpec.js
@@ -412,7 +412,37 @@ describe('Timepicker feature', function() {
 
     expect(tp2.minute).toBe(30);
   });
+  
+  it('should increment minutes with incrementMinute method using Step and Rounding when initial value is not a Multiple of the Step', function () {
+      expect(tp1).toBeDefined();
+      expect(tp1.minuteStep).toBe(15);
 
+      tp1.setTime('11:00');                         //Quick test to verify expected results
+      var currentTime = tp1.getTime();
+      expect(currentTime).toBeDefined();
+      expect(currentTime).toBe('11:00 AM');
+
+      tp1.incrementMinute();
+      currentTime = tp1.getTime();
+      expect(currentTime).toBeDefined();
+      expect(currentTime).toBe('11:15 AM');
+
+      tp1.setTime('11:02');                         //Setup test with a time that is not a multiple of step
+      currentTime = tp1.getTime();
+      expect(currentTime).toBeDefined();
+      expect(currentTime).toBe('11:02 AM');
+
+      tp1.incrementMinute();
+      currentTime = tp1.getTime();
+      expect(currentTime).toBeDefined();
+      expect(currentTime).toBe('11:15 AM');
+
+      tp1.incrementMinute();                        //After the first rounded-increment, make sure further increments follow step
+      currentTime = tp1.getTime();
+      expect(currentTime).toBeDefined();
+      expect(currentTime).toBe('11:30 AM');
+  });
+  
   it('should decrement minutes with decrementMinute method', function() {
     tp1.hour = 11;
     tp1.minute = 0;
@@ -428,7 +458,37 @@ describe('Timepicker feature', function() {
     expect(tp2.hour).toBe(10);
     expect(tp2.minute).toBe(30);
   });
+  
+  it('should decrement minutes with decrementMinute method using Step and Rounding when initial value is not a Multiple of the Step', function () {
+      expect(tp1).toBeDefined();
+      expect(tp1.minuteStep).toBe(15);
 
+      tp1.setTime('11:00');                         //Quick test to verify expected results
+      var currentTime = tp1.getTime();
+      expect(currentTime).toBeDefined();
+      expect(currentTime).toBe('11:00 AM');
+
+      tp1.decrementMinute();
+      currentTime = tp1.getTime();
+      expect(currentTime).toBeDefined();
+      expect(currentTime).toBe('10:45 AM');
+
+      tp1.setTime('11:02');                         //Setup test with a time that is not a multiple of step
+      currentTime = tp1.getTime();
+      expect(currentTime).toBeDefined();
+      expect(currentTime).toBe('11:02 AM');
+
+      tp1.decrementMinute();
+      currentTime = tp1.getTime();
+      expect(currentTime).toBeDefined();
+      expect(currentTime).toBe('11:00 AM');
+
+      tp1.decrementMinute();                        //After the first rounded-decrement, make sure further decrements follow step
+      currentTime = tp1.getTime();
+      expect(currentTime).toBeDefined();
+      expect(currentTime).toBe('10:45 AM');
+  });
+  
   it('should increment hour if minutes increment past 59', function() {
     $input1.val('11:55 AM');
     tp1.updateFromElementVal();

--- a/spec/js/TimepickerSpec.js
+++ b/spec/js/TimepickerSpec.js
@@ -412,37 +412,37 @@ describe('Timepicker feature', function() {
 
     expect(tp2.minute).toBe(30);
   });
-  
+
   it('should increment minutes with incrementMinute method using Step and Rounding when initial value is not a Multiple of the Step', function () {
-      expect(tp1).toBeDefined();
-      expect(tp1.minuteStep).toBe(15);
+    expect(tp1).toBeDefined();
+    expect(tp1.minuteStep).toBe(15);
 
-      tp1.setTime('11:00');                         //Quick test to verify expected results
-      var currentTime = tp1.getTime();
-      expect(currentTime).toBeDefined();
-      expect(currentTime).toBe('11:00 AM');
+    tp1.setTime('11:00');                         //Quick test to verify expected results
+    var currentTime = tp1.getTime();
+    expect(currentTime).toBeDefined();
+    expect(currentTime).toBe('11:00 AM');
 
-      tp1.incrementMinute();
-      currentTime = tp1.getTime();
-      expect(currentTime).toBeDefined();
-      expect(currentTime).toBe('11:15 AM');
+    tp1.incrementMinute();
+    currentTime = tp1.getTime();
+    expect(currentTime).toBeDefined();
+    expect(currentTime).toBe('11:15 AM');
 
-      tp1.setTime('11:02');                         //Setup test with a time that is not a multiple of step
-      currentTime = tp1.getTime();
-      expect(currentTime).toBeDefined();
-      expect(currentTime).toBe('11:02 AM');
+    tp1.setTime('11:02');                         //Setup test with a time that is not a multiple of step
+    currentTime = tp1.getTime();
+    expect(currentTime).toBeDefined();
+    expect(currentTime).toBe('11:02 AM');
 
-      tp1.incrementMinute();
-      currentTime = tp1.getTime();
-      expect(currentTime).toBeDefined();
-      expect(currentTime).toBe('11:15 AM');
+    tp1.incrementMinute();
+    currentTime = tp1.getTime();
+    expect(currentTime).toBeDefined();
+    expect(currentTime).toBe('11:15 AM');
 
-      tp1.incrementMinute();                        //After the first rounded-increment, make sure further increments follow step
-      currentTime = tp1.getTime();
-      expect(currentTime).toBeDefined();
-      expect(currentTime).toBe('11:30 AM');
+    tp1.incrementMinute();                        //After the first rounded-increment, make sure further increments follow step
+    currentTime = tp1.getTime();
+    expect(currentTime).toBeDefined();
+    expect(currentTime).toBe('11:30 AM');
   });
-  
+
   it('should decrement minutes with decrementMinute method', function() {
     tp1.hour = 11;
     tp1.minute = 0;
@@ -458,37 +458,37 @@ describe('Timepicker feature', function() {
     expect(tp2.hour).toBe(10);
     expect(tp2.minute).toBe(30);
   });
-  
+
   it('should decrement minutes with decrementMinute method using Step and Rounding when initial value is not a Multiple of the Step', function () {
-      expect(tp1).toBeDefined();
-      expect(tp1.minuteStep).toBe(15);
+    expect(tp1).toBeDefined();
+    expect(tp1.minuteStep).toBe(15);
 
-      tp1.setTime('11:00');                         //Quick test to verify expected results
-      var currentTime = tp1.getTime();
-      expect(currentTime).toBeDefined();
-      expect(currentTime).toBe('11:00 AM');
+    tp1.setTime('11:00');                         //Quick test to verify expected results
+    var currentTime = tp1.getTime();
+    expect(currentTime).toBeDefined();
+    expect(currentTime).toBe('11:00 AM');
 
-      tp1.decrementMinute();
-      currentTime = tp1.getTime();
-      expect(currentTime).toBeDefined();
-      expect(currentTime).toBe('10:45 AM');
+    tp1.decrementMinute();
+    currentTime = tp1.getTime();
+    expect(currentTime).toBeDefined();
+    expect(currentTime).toBe('10:45 AM');
 
-      tp1.setTime('11:02');                         //Setup test with a time that is not a multiple of step
-      currentTime = tp1.getTime();
-      expect(currentTime).toBeDefined();
-      expect(currentTime).toBe('11:02 AM');
+    tp1.setTime('11:02');                         //Setup test with a time that is not a multiple of step
+    currentTime = tp1.getTime();
+    expect(currentTime).toBeDefined();
+    expect(currentTime).toBe('11:02 AM');
 
-      tp1.decrementMinute();
-      currentTime = tp1.getTime();
-      expect(currentTime).toBeDefined();
-      expect(currentTime).toBe('11:00 AM');
+    tp1.decrementMinute();
+    currentTime = tp1.getTime();
+    expect(currentTime).toBeDefined();
+    expect(currentTime).toBe('11:00 AM');
 
-      tp1.decrementMinute();                        //After the first rounded-decrement, make sure further decrements follow step
-      currentTime = tp1.getTime();
-      expect(currentTime).toBeDefined();
-      expect(currentTime).toBe('10:45 AM');
+    tp1.decrementMinute();                        //After the first rounded-decrement, make sure further decrements follow step
+    currentTime = tp1.getTime();
+    expect(currentTime).toBeDefined();
+    expect(currentTime).toBe('10:45 AM');
   });
-  
+
   it('should increment hour if minutes increment past 59', function() {
     $input1.val('11:55 AM');
     tp1.updateFromElementVal();


### PR DESCRIPTION
Updated bootstrap-timepicker.js to add functionality to round to the next step during decrement when the initial value is not a multiple of the step (similar to incrementMinute).  During the call to decrementMinute, when the value is '02' and step is '15', the new value will become '00' and further decrements will following the step (02 -> 00 -> 45 -> 30).

incrementMinute follows this same behavior already (02 -> 15 -> 30 -> 45).

Added UnitTest test cases to test this scenario (for both incrementMinute and decrementMinute).
