### PR TITLE
Disable for input with readonly attribute

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -914,6 +914,10 @@
       if (this.$element.is(':disabled')) {
         return;
       }
+      
+      if (this.$element.is('[readonly]')) {
+        return;
+      }
 
       // show/hide approach taken by datepicker
       this.$widget.appendTo(this.appendWidgetTo);


### PR DESCRIPTION
Not show widget for input with attribute 'readonly'.
