### PR TITLE
zIndex not correct

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -663,7 +663,7 @@
       var widgetWidth = this.$widget.outerWidth(), widgetHeight = this.$widget.outerHeight(), visualPadding = 10, windowWidth =
         $(window).width(), windowHeight = $(window).height(), scrollTop = $(window).scrollTop();
 
-      var zIndex = parseInt(this.$element.parents().filter(function() { return $(this).css('z-index') !== 'auto'; }).first().css('z-index'), 10) + 10;
+      var zIndex = Math.max.apply(Math, this.$element.parents().filter(function() { return $(this).css('z-index') !== 'auto'; }).map(function() { return parseInt($(this).css('z-index'), 10); }));
       var offset = this.component ? this.component.parent().offset() : this.$element.offset();
       var height = this.component ? this.component.outerHeight(true) : this.$element.outerHeight(false);
       var width = this.component ? this.component.outerWidth(true) : this.$element.outerWidth(false);


### PR DESCRIPTION
When displaying the widget, the domtree is scanned, but only gets the z-index of the "top-most" parent which doesn't have "z-index: auto;".
This change will let it get the highest z-index value, instead of the "top-most not auto" z-index.
