### PR TITLE
Fixed typo, making the correct icon appear on github pages.

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@ title: Timepicker for Twitter Bootstrap
     <hr class="soften">
     <p>Inside a modal with 24hr mode and seconds enabled.</p>
     <div class="input-group bootstrap-timepicker timepicker">
-        <input id="timepicker2" class="form-control input-small" type="text"/><span class="input-group-addon"><i class="glyphicon glyphiicon-time"></i></span>
+        <input id="timepicker2" class="form-control input-small" type="text"/><span class="input-group-addon"><i class="glyphicon glyphicon-time"></i></span>
     </div>
     &nbsp;
     <a href="#timepicker2Source" data-toggle="collapse">+ View Source</a>


### PR DESCRIPTION
Just fixed a typo, so the icon shows on one of the examples whenever someone visits the repository page.