### PR TITLE
Fix Android Input Handling: Key Code 229 Not Captured

### DIFF
--- a/js/bootstrap-timepicker.js
+++ b/js/bootstrap-timepicker.js
@@ -1109,7 +1109,7 @@
     },
 
     widgetKeyup: function(e) {
-      if ((e.which === 65) || (e.which === 77) || (e.which === 80) || (e.which === 46) || (e.which === 8) || (e.which >= 48 && e.which <= 57) || (e.which >= 96 && e.which <= 105)) {
+      if ((e.which === 65) || (e.which === 77) || (e.which === 80) || (e.which === 46) || (e.which === 8) || (e.which >= 48 && e.which <= 57) || (e.which >= 96 && e.which <= 105) || (e.which === 229)) {
         this.updateFromWidgetInputs();
       }
     }


### PR DESCRIPTION
On Android devices, the timepicker widget fails to capture input values due to a limitation with virtual keyboards sending key code 229 instead of traditional key events. This results in the widget not updating properly or responding to user input.

**Steps to Reproduce:**
1. Open the timepicker widget on an Android mobile device.
2. Try to manually enter a time using the on-screen keyboard.
3. Notice that the timepicker doesn't update or reflect the entered value.

**Expected Behavior:**
The widget should properly handle input events, including key code 229, which is used by Android's virtual keyboards.

**Actual Behavior:**
Input events triggered by key code 229 are not processed, preventing the widget from updating.

**Proposed Solution:**
Add an additional check for `e.which === 229` in the `widgetKeyup` event handler to ensure that input events from Android devices are captured and processed correctly.

**Additional Notes:**
- The issue only occurs on Android devices. The widget's behavior on iOS is unaffected.
- I have attached a short video demonstrating the issue on Android devices for better context.








https://github.com/user-attachments/assets/4286dbc3-dc3d-46f1-b9f5-fb03beb74bbb
